### PR TITLE
Init token metadata

### DIFF
--- a/src/IlliniBlockchainSP22Token.sol
+++ b/src/IlliniBlockchainSP22Token.sol
@@ -4,7 +4,22 @@ pragma solidity ^0.8.6;
 import {ERC1155} from "solmate/tokens/ERC1155.sol";
 
 contract IlliniBlockchainSP22Token is ERC1155 {
-    function uri(uint256) public pure virtual override returns (string memory) {
-        
+    struct TokenMetadata {
+        uint8 year;
+        uint8 termId;
     }
+    string[] internal terms;
+    mapping(uint256 => TokenMetadata) public tokenMetadata;
+
+    constructor() public {
+        terms = ["Fall", "Spring"];
+    }
+
+    function uri(uint256)
+        public
+        pure
+        virtual
+        override
+        returns (string memory)
+    {}
 }


### PR DESCRIPTION
Initial metadata struct needed from minting and used for token URI. Starts #3.